### PR TITLE
fix: rm use of module.isBuiltin for older node versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "5.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/src/is-builtin.ts
+++ b/src/is-builtin.ts
@@ -1,0 +1,11 @@
+import module from 'module'
+
+const moduleSet = new Set(module.builtinModules)
+const NODE_PROTOCOL = 'node:'
+
+export const isBuiltin = (moduleName: string): boolean => {
+  if (moduleName.startsWith(NODE_PROTOCOL)) {
+    moduleName = moduleName.slice(NODE_PROTOCOL.length)
+  }
+  return moduleSet.has(moduleName)
+}

--- a/src/resolve-import.ts
+++ b/src/resolve-import.ts
@@ -3,13 +3,13 @@
  * @module
  */
 import { realpath } from 'fs/promises'
-import { isBuiltin } from 'module'
 import { basename, dirname, isAbsolute, resolve } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 import {
   moduleNotFound,
   relativeImportWithoutParentURL,
 } from './errors.js'
+import { isBuiltin } from './is-builtin.js'
 import { fileExists } from './file-exists.js'
 import { ResolveImportOpts } from './index.js'
 import { isRelativeRequire } from './is-relative-require.js'


### PR DESCRIPTION
I'm doing some work to migrate tap@19 and given `tap` still has an invalid engine largely because of this (and some node 20.5 loader issues, pr on the way)

tap should be (i did some automation to get these numbers)

```
>=16.17.0 <=16.20.2||>=18.6.0 <=18.20.3||>=19.0.0 <=19.5.0||>=20.6.0
// or
>=16.17.0 <=16.20.2||>=18.6.0 <=19.5.0||>=20.6.0
```

with this pr it would reflect tap would be closer to `"node": ">=16"` (with some exceptions because of the loader issues)

related convo here https://github.com/isaacs/resolve-import/issues/4

I've tried to make somekind of shim but doesn't work because this is esm.

```
NODE_OPTIONS='--require=./module-is-builtin-shim.js' tap"
```

I know supporting older versions / shimming easier to use native functions is a pain totally understandable if we don't wanna support this.